### PR TITLE
Add WebFlux example modules for Phase 4-7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ feature_flag = { strictly = "4.0.0" }
 # spring boot
 #########################################
 spring-boot-starter-webmvc = { module = "org.springframework.boot:spring-boot-starter-webmvc" }
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
 spring-boot-starter-thymeleaf = { module = "org.springframework.boot:spring-boot-starter-thymeleaf" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
@@ -24,6 +25,7 @@ postgresql-jdbc = { module = "org.postgresql:postgresql" }
 feature-flag-spring-boot-starter-core = { module = "net.bright-room.feature-flag-spring-boot-starter:core", version.ref = "feature_flag" }
 feature-flag-spring-boot-starter-webmvc = { module = "net.bright-room.feature-flag-spring-boot-starter:webmvc", version.ref = "feature_flag" }
 feature-flag-spring-boot-starter-actuator = { module = "net.bright-room.feature-flag-spring-boot-starter:actuator", version.ref = "feature_flag" }
+feature-flag-spring-boot-starter-webflux = { module = "net.bright-room.feature-flag-spring-boot-starter:webflux", version.ref = "feature_flag" }
 
 #########################################
 # gradle plugins

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,4 +26,11 @@ include(
     "webmvc:functional-endpoint",
     "webmvc:actuator-endpoint",
     "webmvc:health-indicator",
+
+    // Phase 4-7: WebFlux examples
+    "webflux:fail-behavior",
+    "webflux:error-handling",
+    "webflux:custom-provider",
+    "webflux:actuator-endpoint",
+    "webflux:health-indicator",
 )

--- a/webflux/actuator-endpoint/build.gradle.kts
+++ b/webflux/actuator-endpoint/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("spring-boot-starter")
+    id("spotless-java")
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.feature.flag.spring.boot.starter.core)
+    implementation(libs.feature.flag.spring.boot.starter.webflux)
+    implementation(libs.feature.flag.spring.boot.starter.actuator)
+}

--- a/webflux/actuator-endpoint/src/main/java/net/brightroom/example/actuator/Application.java
+++ b/webflux/actuator-endpoint/src/main/java/net/brightroom/example/actuator/Application.java
@@ -1,0 +1,12 @@
+package net.brightroom.example.actuator;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/webflux/actuator-endpoint/src/main/java/net/brightroom/example/actuator/DemoController.java
+++ b/webflux/actuator-endpoint/src/main/java/net/brightroom/example/actuator/DemoController.java
@@ -1,0 +1,22 @@
+package net.brightroom.example.actuator;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class DemoController {
+
+  @GetMapping("/api/demo")
+  @FeatureFlag("demo-feature")
+  public Mono<String> demo() {
+    return Mono.just("demo-feature is enabled!");
+  }
+
+  @GetMapping("/api/another")
+  @FeatureFlag("another-feature")
+  public Mono<String> another() {
+    return Mono.just("another-feature is enabled!");
+  }
+}

--- a/webflux/actuator-endpoint/src/main/java/net/brightroom/example/actuator/FeatureFlagEventListener.java
+++ b/webflux/actuator-endpoint/src/main/java/net/brightroom/example/actuator/FeatureFlagEventListener.java
@@ -1,0 +1,35 @@
+package net.brightroom.example.actuator;
+
+import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
+import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeatureFlagEventListener {
+
+  private static final Logger log = LoggerFactory.getLogger(FeatureFlagEventListener.class);
+
+  @EventListener
+  public void onFeatureFlagChanged(FeatureFlagChangedEvent event) {
+    if (event.rolloutPercentage() != null) {
+      log.info(
+          "[FeatureFlagChangedEvent] featureName={}, enabled={}, rollout={}",
+          event.featureName(),
+          event.enabled(),
+          event.rolloutPercentage());
+    } else {
+      log.info(
+          "[FeatureFlagChangedEvent] featureName={}, enabled={}",
+          event.featureName(),
+          event.enabled());
+    }
+  }
+
+  @EventListener
+  public void onFeatureFlagRemoved(FeatureFlagRemovedEvent event) {
+    log.info("[FeatureFlagRemovedEvent] featureName={}", event.featureName());
+  }
+}

--- a/webflux/actuator-endpoint/src/main/resources/application.yml
+++ b/webflux/actuator-endpoint/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+feature-flags:
+  features:
+    demo-feature:
+      enabled: true
+      rollout: 80
+    another-feature:
+      enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: feature-flags,health

--- a/webflux/custom-provider/build.gradle.kts
+++ b/webflux/custom-provider/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("spring-boot-starter")
+    id("spotless-java")
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.feature.flag.spring.boot.starter.core)
+    implementation(libs.feature.flag.spring.boot.starter.webflux)
+}

--- a/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/Application.java
+++ b/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/Application.java
@@ -1,0 +1,12 @@
+package net.brightroom.example.customprovider;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/DemoController.java
+++ b/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/DemoController.java
@@ -1,0 +1,24 @@
+package net.brightroom.example.customprovider;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api")
+public class DemoController {
+
+  @GetMapping("/reactive-feature")
+  @FeatureFlag("reactive-feature")
+  public Mono<String> reactiveFeature() {
+    return Mono.just("reactive-feature is enabled via custom provider!");
+  }
+
+  @GetMapping("/beta-feature")
+  @FeatureFlag("beta-feature")
+  public Mono<String> betaFeature() {
+    return Mono.just("beta-feature is enabled via custom provider!");
+  }
+}

--- a/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/ExternalConfigProperties.java
+++ b/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/ExternalConfigProperties.java
@@ -1,0 +1,18 @@
+package net.brightroom.example.customprovider;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("external-feature-flags")
+public class ExternalConfigProperties {
+
+  private Map<String, Boolean> flags = Map.of();
+
+  public Map<String, Boolean> getFlags() {
+    return flags;
+  }
+
+  public void setFlags(Map<String, Boolean> flags) {
+    this.flags = flags;
+  }
+}

--- a/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/ExternalConfigReactiveFeatureFlagProvider.java
+++ b/webflux/custom-provider/src/main/java/net/brightroom/example/customprovider/ExternalConfigReactiveFeatureFlagProvider.java
@@ -1,0 +1,27 @@
+package net.brightroom.example.customprovider;
+
+import java.util.Map;
+import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@EnableConfigurationProperties(ExternalConfigProperties.class)
+public class ExternalConfigReactiveFeatureFlagProvider implements ReactiveFeatureFlagProvider {
+
+  private final Map<String, Boolean> flags;
+
+  public ExternalConfigReactiveFeatureFlagProvider(ExternalConfigProperties properties) {
+    this.flags = Map.copyOf(properties.getFlags());
+  }
+
+  @Override
+  public Mono<Boolean> isFeatureEnabled(String featureName) {
+    Boolean enabled = flags.get(featureName);
+    if (enabled == null) {
+      return Mono.empty();
+    }
+    return Mono.just(enabled);
+  }
+}

--- a/webflux/custom-provider/src/main/resources/application.yml
+++ b/webflux/custom-provider/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+external-feature-flags:
+  flags:
+    reactive-feature: true
+    beta-feature: false

--- a/webflux/error-handling/build.gradle.kts
+++ b/webflux/error-handling/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("spring-boot-starter")
+    id("spotless-java")
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.feature.flag.spring.boot.starter.core)
+    implementation(libs.feature.flag.spring.boot.starter.webflux)
+}

--- a/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/Application.java
+++ b/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/Application.java
@@ -1,0 +1,12 @@
+package net.brightroom.example.errorhandling;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/CustomExceptionHandler.java
+++ b/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/CustomExceptionHandler.java
@@ -1,0 +1,26 @@
+package net.brightroom.example.errorhandling;
+
+import java.util.Map;
+import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Order(0)
+@Profile("json-error")
+public class CustomExceptionHandler {
+
+  @ExceptionHandler(FeatureFlagAccessDeniedException.class)
+  public ResponseEntity<Map<String, Object>> handle(FeatureFlagAccessDeniedException e) {
+    Map<String, Object> body =
+        Map.of(
+            "error", "Feature Unavailable",
+            "feature", e.featureName(),
+            "message", "This feature is currently disabled.");
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+  }
+}

--- a/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/CustomHandlerFilterResolution.java
+++ b/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/CustomHandlerFilterResolution.java
@@ -1,0 +1,28 @@
+package net.brightroom.example.errorhandling;
+
+import java.util.Map;
+import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@Profile("functional-error")
+public class CustomHandlerFilterResolution implements AccessDeniedHandlerFilterResolution {
+
+  @Override
+  public Mono<ServerResponse> resolve(ServerRequest request, FeatureFlagAccessDeniedException e) {
+    return ServerResponse.status(HttpStatus.FORBIDDEN)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            Map.of(
+                "error", "Feature Unavailable",
+                "feature", e.featureName(),
+                "message", "This feature is currently disabled."));
+  }
+}

--- a/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/FunctionalRoutingConfiguration.java
+++ b/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/FunctionalRoutingConfiguration.java
@@ -1,0 +1,30 @@
+package net.brightroom.example.errorhandling;
+
+import net.brightroom.featureflag.webflux.filter.FeatureFlagHandlerFilterFunction;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+@Profile("functional-error")
+public class FunctionalRoutingConfiguration {
+
+  private final FeatureFlagHandlerFilterFunction featureFlagFilter;
+
+  @Bean
+  public RouterFunction<ServerResponse> functionalRoutes() {
+    return RouterFunctions.route()
+        .GET(
+            "/functional/premium",
+            req -> ServerResponse.ok().bodyValue("Functional premium feature is available!"))
+        .filter(featureFlagFilter.of("premium-feature"))
+        .build();
+  }
+
+  public FunctionalRoutingConfiguration(FeatureFlagHandlerFilterFunction featureFlagFilter) {
+    this.featureFlagFilter = featureFlagFilter;
+  }
+}

--- a/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/PremiumController.java
+++ b/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/PremiumController.java
@@ -1,0 +1,23 @@
+package net.brightroom.example.errorhandling;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api")
+public class PremiumController {
+
+  @GetMapping("/premium")
+  @FeatureFlag("premium-feature")
+  public Mono<String> premium() {
+    return Mono.just("Premium feature is available!");
+  }
+
+  @GetMapping("/coming-soon")
+  public Mono<String> comingSoon() {
+    return Mono.just("This feature is coming soon. Stay tuned!");
+  }
+}

--- a/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/RedirectExceptionHandler.java
+++ b/webflux/error-handling/src/main/java/net/brightroom/example/errorhandling/RedirectExceptionHandler.java
@@ -1,0 +1,20 @@
+package net.brightroom.example.errorhandling;
+
+import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Order(0)
+@Profile("redirect")
+public class RedirectExceptionHandler {
+
+  @ExceptionHandler(FeatureFlagAccessDeniedException.class)
+  public ResponseEntity<Void> handle(FeatureFlagAccessDeniedException e) {
+    return ResponseEntity.status(HttpStatus.FOUND).header("Location", "/api/coming-soon").build();
+  }
+}

--- a/webflux/error-handling/src/main/resources/application.yml
+++ b/webflux/error-handling/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+feature-flags:
+  features:
+    premium-feature:
+      enabled: false

--- a/webflux/fail-behavior/build.gradle.kts
+++ b/webflux/fail-behavior/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("spring-boot-starter")
+    id("spotless-java")
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.feature.flag.spring.boot.starter.core)
+    implementation(libs.feature.flag.spring.boot.starter.webflux)
+}

--- a/webflux/fail-behavior/src/main/java/net/brightroom/example/failbehavior/Application.java
+++ b/webflux/fail-behavior/src/main/java/net/brightroom/example/failbehavior/Application.java
@@ -1,0 +1,12 @@
+package net.brightroom.example.failbehavior;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/webflux/fail-behavior/src/main/java/net/brightroom/example/failbehavior/FailClosedController.java
+++ b/webflux/fail-behavior/src/main/java/net/brightroom/example/failbehavior/FailClosedController.java
@@ -1,0 +1,24 @@
+package net.brightroom.example.failbehavior;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/fail-closed")
+public class FailClosedController {
+
+  @GetMapping("/known")
+  @FeatureFlag("known-feature")
+  public Mono<String> known() {
+    return Mono.just("Known feature is enabled");
+  }
+
+  @GetMapping("/unknown")
+  @FeatureFlag("undefined-feature")
+  public Mono<String> unknown() {
+    return Mono.just("This should not be reached (fail-closed)");
+  }
+}

--- a/webflux/fail-behavior/src/main/java/net/brightroom/example/failbehavior/FailOpenController.java
+++ b/webflux/fail-behavior/src/main/java/net/brightroom/example/failbehavior/FailOpenController.java
@@ -1,0 +1,24 @@
+package net.brightroom.example.failbehavior;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/fail-open")
+public class FailOpenController {
+
+  @GetMapping("/known-disabled")
+  @FeatureFlag("known-disabled")
+  public Mono<String> knownDisabled() {
+    return Mono.just("This should not be reached (explicitly disabled)");
+  }
+
+  @GetMapping("/unknown")
+  @FeatureFlag("undefined-feature")
+  public Mono<String> unknown() {
+    return Mono.just("Undefined feature is allowed (fail-open)");
+  }
+}

--- a/webflux/fail-behavior/src/main/resources/application-fail-open.yml
+++ b/webflux/fail-behavior/src/main/resources/application-fail-open.yml
@@ -1,0 +1,5 @@
+feature-flags:
+  features:
+    known-disabled:
+      enabled: false
+  default-enabled: true

--- a/webflux/fail-behavior/src/main/resources/application.yml
+++ b/webflux/fail-behavior/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+feature-flags:
+  features:
+    known-feature:
+      enabled: true
+    known-disabled:
+      enabled: false

--- a/webflux/health-indicator/build.gradle.kts
+++ b/webflux/health-indicator/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("spring-boot-starter")
+    id("spotless-java")
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.webflux)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.feature.flag.spring.boot.starter.core)
+    implementation(libs.feature.flag.spring.boot.starter.webflux)
+    implementation(libs.feature.flag.spring.boot.starter.actuator)
+}

--- a/webflux/health-indicator/src/main/java/net/brightroom/example/healthindicator/Application.java
+++ b/webflux/health-indicator/src/main/java/net/brightroom/example/healthindicator/Application.java
@@ -1,0 +1,12 @@
+package net.brightroom.example.healthindicator;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/webflux/health-indicator/src/main/java/net/brightroom/example/healthindicator/DemoController.java
+++ b/webflux/health-indicator/src/main/java/net/brightroom/example/healthindicator/DemoController.java
@@ -1,0 +1,24 @@
+package net.brightroom.example.healthindicator;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api")
+public class DemoController {
+
+  @GetMapping("/active")
+  @FeatureFlag("active-feature")
+  public Mono<String> active() {
+    return Mono.just("active-feature is enabled!");
+  }
+
+  @GetMapping("/inactive")
+  @FeatureFlag("inactive-feature")
+  public Mono<String> inactive() {
+    return Mono.just("inactive-feature is enabled!");
+  }
+}

--- a/webflux/health-indicator/src/main/resources/application.yml
+++ b/webflux/health-indicator/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+feature-flags:
+  features:
+    active-feature:
+      enabled: true
+    inactive-feature:
+      enabled: false
+    rollout-feature:
+      enabled: true
+      rollout: 50
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,feature-flags
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
- webflux/fail-behavior: fail-closed / fail-open behavior demo
- webflux/error-handling: custom @ControllerAdvice and AccessDeniedHandlerFilterResolution patterns
- webflux/custom-provider: ReactiveFeatureFlagProvider custom implementation
- webflux/actuator-endpoint: runtime flag management via ReactiveFeatureFlagEndpoint
- webflux/health-indicator: ReactiveFeatureFlagHealthIndicator demo

Also adds spring-boot-starter-webflux and feature-flag-spring-boot-starter-webflux to libs.versions.toml, and registers the new modules in settings.gradle.kts.